### PR TITLE
Added ability to send parameter to a task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,15 +2,15 @@
 # It is not intended for manual editing.
 [[package]]
 name = "cc"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fe_rtos"
 version = "0.1.0"
 dependencies = [
- "cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "c9ce8bb087aacff865633f0bd5aeaed910fe2fe55b55f4739527f2e023a2e53d"
+"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"


### PR DESCRIPTION
I'm not sure how I feel about using *const u32 to pass the pointer to the parameter because by using, we're losing some of Rust's safety checks and have to deal with tedious casting.
I tried replacing it with Box, which would have the additional benefit of guaranteeing the address won't become invalid from leaving scope. The problem with that I would either have to declare a type for the box when defining ep in the Task struct or make the Task struct generic. However, if I make the Task struct generic, I would have to declare one type for the entire task list at compile time.
I am open to other suggestions.

Resolves #13 