### PR TITLE
Added syscalls

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() -> Result<(), Box<Error>> {
     File::create(out_dir.join("link.x"))?.write_all(include_bytes!("link.x"))?;
 
     Build::new().file("./src/arm.s").compile("asm");
+    Build::new().file("./src/arm_syscall.s").compile("syscall_asm");
 
     Ok(())
 }

--- a/link.x
+++ b/link.x
@@ -9,8 +9,11 @@ MEMORY
 /* The entry point is the reset handler */
 ENTRY(Reset);
 
+/* Needed to avoid linker from rudely throwing away these symbols*/
 EXTERN(RESET_VECTOR);
 EXTERN(EXCEPTIONS);
+EXTERN(sys_exit);
+EXTERN(sys_sleep);
 
 SECTIONS
 {

--- a/src/arm_syscall.s
+++ b/src/arm_syscall.s
@@ -1,0 +1,53 @@
+    .syntax unified
+    .section .text.asm
+    .weak sys_exit
+    .weak sys_sleep
+    .global svc_handler
+
+.equ max_svc, 1
+
+    .thumb_func
+//Do not overwrite R0-R3 because they hold the syscall params
+svc_handler:
+    PUSH {R4, R5, LR}
+
+    //////////////////////////////
+    //Retrieve the syscall number
+    //////////////////////////////
+
+    //Find the stacked PC
+    //Offest is 24(decimal) + (registers pushed * 4)
+    LDR R4, [SP, 0x24]
+    //Get the svc instruction
+    LDRH R4, [R4, -2]
+    //Get the syscall number from the instruction
+    BIC R4, R4, 0xFF00
+
+    //////////////////////////////
+    //Call the syscall
+    //////////////////////////////
+
+    //Determine if the syscall number is valid
+    CMP R4, max_svc
+    BGT svc_handler_end
+
+    //If it is valid, jump to the right place
+    ADR R5, svc_jump_table
+    LDR PC, [R5, R4, LSL 2]
+
+.align 4
+svc_jump_table:
+    .word svc0 //exit
+    .word svc1 //sleep
+
+    .thumb_func
+svc0:
+    BL sys_exit
+    B svc_handler_end
+    .thumb_func
+svc1:
+    BL sys_sleep
+    B svc_handler_end
+    .thumb_func
+svc_handler_end:
+    POP {R4, R5, PC}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod fe_alloc;
 pub mod task;
+pub mod syscall;
 
 use core::panic::PanicInfo;
 use core::ptr;

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -1,0 +1,17 @@
+use super::task;
+
+extern "C" {
+    pub fn svc_handler();
+}
+
+#[no_mangle]
+extern "C" fn sys_exit() {
+    unsafe { task::remove_task(); }
+}
+
+#[no_mangle]
+extern "C" fn sys_sleep(seconds: u32) {
+    let ms: u64 = 1000 * seconds as u64;
+    task::sleep(ms);
+}
+

--- a/src/task.rs
+++ b/src/task.rs
@@ -119,12 +119,6 @@ pub fn sleep(sleep_ticks: u64) {
         TASKS[TASK_INDEX].state = TaskState::Asleep;
         //Trigger a context switch and wait until that happens
         do_context_switch();
-        loop {
-            match TASKS[TASK_INDEX].state {
-                TaskState::Asleep => (),
-                _ => break,
-            }
-        }
     }
 }
 
@@ -201,7 +195,6 @@ pub unsafe fn add_task_static(stack_ptr: &'static u32, stack_size: usize, entry_
 pub unsafe fn remove_task() {
     TASKS[TASK_INDEX].state = TaskState::Zombie;
     do_context_switch();
-    loop {}
 }
 
 pub fn start_scheduler(trigger_context_switch: fn(), enable_systick: fn(u32), reload_val: u32) {


### PR DESCRIPTION
The one limitation I see with this is that system calls cannot have more than 4 arguments. This is because the first 4 arguments are put in registers R0-R3 and the rest are put on the stack, and I didn't want to deal with fiddling with the stack atm. This functionality can be added later if needed.

Resolves #4 