### PR TITLE
Make sure the syscalls get linked

### DIFF
--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -4,6 +4,10 @@ extern "C" {
     pub fn svc_handler();
 }
 
+//For the linker to link the syscalls, a function in this
+//file must be called from elsewhere...
+pub fn link_syscalls(){}
+
 #[no_mangle]
 extern "C" fn sys_exit() {
     unsafe { task::remove_task(); }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
 
+use crate::syscall;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -204,6 +205,7 @@ pub unsafe fn remove_task() {
 }
 
 pub fn start_scheduler<F>(trigger_context_switch: fn(), enable_systick: F, reload_val: u32) where F: FnOnce(u32)  {
+    syscall::link_syscalls();
 
     unsafe {
         add_task_static(&KERNEL_STACK[0], DEFAULT_STACK_SIZE, kernel, None);


### PR DESCRIPTION
Since they are not directly called by the rust code, they
are in danger of being thrown away by the linker.

Signed-off-by: Bijan Tabatabai <bijan311@yahoo.com>