### PR TITLE
Remove a task from the task list by using LinkedList::remove

### DIFF
--- a/fe_rtos/src/lib.rs
+++ b/fe_rtos/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(const_mut_refs)]
+#![feature(linked_list_remove)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -352,26 +352,19 @@ fn kernel(_: &mut u32) {
 
         //Delete a task if there's a task to be deleted
         if delete_task {
-            let mut split_list = task_list.split_off(deleted_task_num);
+            //If this task has been removed, remove it from the list
+            //and rust will dealloc almost eveything
+            let removed_task = task_list.remove(deleted_task_num);
 
-            match split_list.pop_front() {
-                Some(task) => {
-                    //If this task has been removed, remove it from the list
-                    //and rust will dealloc everything
-                    match &task.task_info {
-                        Some(info) => {
-                            if !info.param.is_null() {
-                                unsafe { core::mem::drop(Box::from_raw(info.param)); }
-                            }
-                        },
-                        None => (),
+            //We still need to manually dealloc the parameter though
+            match &removed_task.task_info {
+                Some(info) => {
+                    if !info.param.is_null() {
+                        unsafe { core::mem::drop(Box::from_raw(info.param)); }
                     }
                 },
                 None => (),
             }
-
-            //Put the task list back together
-            task_list.append(&mut split_list);
         }
 
         //Going through the loop multiple times without anything else running is

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -338,7 +338,6 @@ fn kernel(_: &mut u32) {
                 TaskState::Zombie => {
                     delete_task = true;
                     deleted_task_num = task_num;
-                    continue;
                 },
                 TaskState::Ignore => {},
             }


### PR DESCRIPTION
Before this was done by splitting the list into two, popping the first element of the second list, then joining the lists back together.
This was cumbersome and verbose, so a smart programmer added a direct remove function to the LinkedList struct.
Thanks to that programmer, we can use LinkedList::remove in our code to make deleting a task cleaner.