### PR TITLE
Make syscalls run in a normal context instead of in the interupt context

### DIFF
--- a/fe_osi/src/arm.s
+++ b/fe_osi/src/arm.s
@@ -9,30 +9,36 @@
 
     .thumb_func
 do_exit:
+    PUSH { LR }
     svc 0x0
-    BX LR
+    POP { PC }
 
     .thumb_func
 do_sleep:
+    PUSH { LR }
     svc 0x1
-    BX LR
+    POP { PC }
 
     .thumb_func
 do_alloc:
+    PUSH { LR }
     svc 0x2
-    BX LR
+    POP { PC }
 
     .thumb_func
 do_dealloc:
+    PUSH { LR }
     svc 0x3
-    BX LR
+    POP { PC }
 
     .thumb_func
 do_block:
+    PUSH { LR }
     svc 0x4
-    BX LR
+    POP { PC }
 
     .thumb_func
 do_task_spawn:
+    PUSH { LR }
     svc 0x5
-    BX LR
+    POP { PC }

--- a/fe_rtos/src/arm_syscall.s
+++ b/fe_rtos/src/arm_syscall.s
@@ -10,80 +10,66 @@
 
 .equ max_svc, 5
 
+///////////////////////////////////////////////////////////////////////////////
+// Arm Cortex-M interrupt stack frame order:
+// high address: xPSR
+//      |         PC
+//      |         LR
+//      |         R12
+//      |         R3
+//      |         R2
+//      |         R1
+//  low address:  R0
+///////////////////////////////////////////////////////////////////////////////
+
     .thumb_func
 //Do not overwrite R0-R3 because they hold the syscall params
 svc_handler:
-    PUSH {R4, R5, LR}
-
-    //////////////////////////////
-    //Load the parameters
-    //////////////////////////////
-    LDR R0, [SP, 0xC]
-    LDR R1, [SP, 0x10]
-    LDR R2, [SP, 0x14]
-    LDR R3, [SP, 0x18]
-
     //////////////////////////////
     //Retrieve the syscall number
     //////////////////////////////
 
     //Find the stacked PC
     //Offest is 24(decimal) + (registers pushed * 4)
-    LDR R4, [SP, 0x24]
+    LDR R0, [SP, 0x18]
     //Get the svc instruction
-    LDRH R4, [R4, -2]
+    LDRH R0, [R0, -2]
     //Get the syscall number from the instruction
-    BIC R4, R4, 0xFF00
+    BIC R0, R0, 0xFF00
 
     //////////////////////////////
-    //Call the syscall
+    //Get the syscall address
     //////////////////////////////
 
     //Determine if the syscall number is valid
-    CMP R4, max_svc
+    CMP R0, max_svc
     BGT svc_handler_end
 
-    //If it is valid, jump to the right place
-    ADR R5, svc_jump_table
-    LDR PC, [R5, R4, LSL 2]
+    //If it is valid, grab the address of the function
+    ADR R1, svc_addr_table
+    LDR R0, [R1, R0, LSL 2]
 
-.align 4
-svc_jump_table:
-    .word svc0 //exit
-    .word svc1 //sleep
-    .word svc2 //alloc
-    .word svc3 //dealloc
-    .word svc4 //block
-    .word svc5 //task spawn
+    //////////////////////////////
+    //Fix the stack
+    //////////////////////////////
+    //The old PC in the ISR stackframe is the new LR in the ISR stackframe
+    LDR R1, [SP, 0x18]
+    //Setting the LSB of LR to 1 indicates that we are in thumb mode
+    ORR R1, R1, 1
+    STR R1, [SP, 0x14]
 
-    .thumb_func
-svc0:
-    BL sys_exit
-    B svc_handler_end
-    .thumb_func
-svc1:
-    BL sys_sleep
-    B svc_handler_end
-    .thumb_func
-svc2:
-    BL sys_alloc
-    B svc_handler_end
-    .thumb_func
-svc3:
-    BL sys_dealloc
-    B svc_handler_end
-    .thumb_func
-svc4:
-    BL sys_block
-    B svc_handler_end
-    .thumb_func
-svc5:
-    BL sys_task_spawn
-    B svc_handler_end
+    //The new PC in the ISR stackframe is where we're jumping to
+    STR R0, [SP, 0x18]
+
     .thumb_func
 svc_handler_end:
-    //Save the return value
-    //Offset to the stored R0 is 0 + (registers pushed * 4)
-    STR R0, [SP, 0xC]
+    BX LR
 
-    POP {R4, R5, PC}
+.align 4
+svc_addr_table:
+    .word sys_exit       // 0
+    .word sys_sleep      // 1
+    .word sys_alloc      // 2
+    .word sys_dealloc    // 3
+    .word sys_block      // 4
+    .word sys_task_spawn // 5

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -109,7 +109,9 @@ unsafe fn scheduler() {
     //Find the next task to run if there is one
     match SCHEDULER_QUEUE.pop() {
         Ok(task) => {
-            let task_state = task.state.try_get().unwrap_or(TaskState::Ignore);
+            //We want to default to Runnable because if a task is in a transition state,
+            //it should be scheduled so it can finish transitioning.
+            let task_state = task.state.try_get().unwrap_or(TaskState::Runnable);
 
             task.queued.store(false, Ordering::SeqCst);
             match task_state {
@@ -306,7 +308,9 @@ fn kernel(_: &mut u32) {
         for task in task_list.iter() {
             let mut new_state = TaskState::Runnable;
             let mut has_new_state = false;
-            let task_state = task.state.try_get().unwrap_or(TaskState::Ignore);
+            //We want to default to Runnable because if a task is in a transition state,
+            //it should be scheduled so it can finish transitioning.
+            let task_state = task.state.try_get().unwrap_or(TaskState::Runnable);
 
             match task_state {
                 TaskState::Runnable => {
@@ -339,7 +343,6 @@ fn kernel(_: &mut u32) {
                     delete_task = true;
                     deleted_task_num = task_num;
                 },
-                TaskState::Ignore => {},
             }
 
             if has_new_state {

--- a/fe_rtos/src/task/task_state.rs
+++ b/fe_rtos/src/task/task_state.rs
@@ -8,7 +8,6 @@ pub enum TaskState {
     Asleep(u64),
     Blocking(*const Semaphore),
     Zombie,
-    Ignore,
 }
 
 pub struct TaskStateStruct {


### PR DESCRIPTION
This gives us a couple of nice properties:
1) You generally want to have interrupts return quickly.
Now we don't have to worry about about how long syscalls take
2) You can now call syscalls in syscalls!
3) Some atomic data structures (e.g. crossebam queues) block a thread until
there is no contention on that structure. This could be problematic if this happens
in an inturrupt because the program would just hang.
Now, if a data structure has contention in the middle of a system call, that thread
will simply be rescheduled and whatever thread is using it can finish.

@dkitzman This patch might make things a little easier for you