### PR TITLE
IPC: Change the message list from a Vec to a custom linked list

### DIFF
--- a/fe_rtos/src/ipc/subscriber.rs
+++ b/fe_rtos/src/ipc/subscriber.rs
@@ -1,19 +1,24 @@
+extern crate alloc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
 use fe_osi::semaphore::Semaphore;
+
+pub(crate) struct MessageNode {
+    pub data: Vec<u8>,
+    pub next: RefCell<Option<Arc<MessageNode>>>,
+}
 
 pub(crate) struct Subscriber {
     pub(crate) lock: Semaphore,
-    pub(crate) index: usize,
+    pub(crate) next_message: Option<Arc<MessageNode>>,
 }
 
 impl Subscriber {
-    pub(crate) fn new(sem: Semaphore, index: Option<usize>) -> Subscriber {
-        let start_index: usize = match index {
-            Some(i) => i,
-            None => 0,
-        };
+    pub(crate) fn new(sem: Semaphore, first_message: Option<Arc<MessageNode>>) -> Subscriber {
         Subscriber {
             lock: sem,
-            index: start_index,
+            next_message: first_message,
         }
     }
 }

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -327,6 +327,8 @@ fn kernel(_: &mut u32) {
                         PUSHING_TASK.store(true, Ordering::SeqCst);
                         SCHEDULER_QUEUE.push(Arc::clone(&task));
                         PUSHING_TASK.store(false, Ordering::SeqCst);
+                    } else if SCHEDULER_QUEUE.is_empty() {
+                        task.queued.store(false, Ordering::SeqCst);
                     }
                 },
                 TaskState::Asleep(wake_up_ticks) => {


### PR DESCRIPTION
This allows the messages that have been read by all of the subscribers to be
freed automatically thanks to Rust's drop mechanics.
It also helps mitagate the problem of running out of memory when the Vec would
resize.

Signed-off-by: Bijan Tabatabai <bijan311@gmail.com>