### PR TITLE
Make fe_rtos less dependent on the cortex_m crate

### DIFF
--- a/fe_osi/build.rs
+++ b/fe_osi/build.rs
@@ -5,11 +5,17 @@ use cc::Build;
 fn main() -> Result<(), Box<dyn Error>> {
     //build directory for this crate
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    //The target architecture
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
     //extend the library search path
     println!("cargo:rustc-link-search={}", out_dir.display());
 
-    Build::new().file("./src/arm.s").compile("asm");
+    if arch == "arm" {
+        Build::new().file("./src/arm.s").compile("asm");
+    } else {
+        panic!("Invalid architecture: {}", arch);
+    }
 
     Ok(())
 }

--- a/fe_rtos/Cargo.toml
+++ b/fe_rtos/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 fe_osi = { path = "../fe_osi" }
-cortex-m = "0.6"
 
 [dependencies.crossbeam-queue]
 version = "0.2"
@@ -20,6 +19,9 @@ features = ["spin_no_std"]
 [dependencies.cstr_core]
 version = "0.1.2"
 features = ["alloc"]
+
+[target.'cfg(target_arch = "arm")'.dependencies]
+cortex-m = "0.6"
 
 [build-dependencies]
 cc = "1.0.25"

--- a/fe_rtos/build.rs
+++ b/fe_rtos/build.rs
@@ -5,14 +5,20 @@ use cc::Build;
 fn main() -> Result<(), Box<dyn Error>> {
     //build directory for this crate
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    //The target architecture
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
     //extend the library search path
     println!("cargo:rustc-link-search={}", out_dir.display());
 
-    Build::new().file("./src/arm.s").compile("asm");
-    Build::new()
-        .file("./src/arm_syscall.s")
-        .compile("syscall_asm");
+    if arch == "arm" {
+        Build::new().file("./src/arm.s").compile("asm");
+        Build::new()
+            .file("./src/arm_syscall.s")
+            .compile("syscall_asm");
+    } else {
+        panic!("Invalid architecture: {}", arch);
+    }
 
     Ok(())
 }

--- a/fe_rtos/src/interrupt.rs
+++ b/fe_rtos/src/interrupt.rs
@@ -1,6 +1,7 @@
 use core::panic::PanicInfo;
 use core::ptr;
 
+#[cfg(target_arch = "arm")]
 pub fn int_register(irqn: i8, int_handler: unsafe extern "C" fn()) {
     //This is defined in the linker script
     extern "C" {

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -294,10 +294,10 @@ pub(crate) unsafe fn remove_task() -> bool {
     ret_val
 }
 
-pub fn start_scheduler(
+pub fn start_scheduler<F: FnOnce(usize)>(
     trigger_context_switch: fn(),
-    mut systick: cortex_m::peripheral::SYST,
-    reload_val: u32,
+    enable_systick: F,
+    reload_val: usize,
 ) {
     syscall::link_syscalls();
 
@@ -315,18 +315,7 @@ pub fn start_scheduler(
         TRIGGER_CONTEXT_SWITCH = trigger_context_switch;
     }
 
-    unsafe {
-        let mut peripherals = cortex_m::Peripherals::steal();
-        peripherals
-            .SCB
-            .set_priority(cortex_m::peripheral::scb::SystemHandler::PendSV, 7);
-    }
-
-    //Basically, wait for the scheduler to start
-    systick.set_reload(reload_val);
-    systick.clear_current();
-    systick.enable_counter();
-    systick.enable_interrupt();
+    enable_systick(reload_val);
 
     loop {}
 }


### PR DESCRIPTION
fe_rtos still needs cortex_m for registering interrupt. However, registering
interrupts is very architechture specific, so I believe it is fine to keep that
as a conditional dependency.

closes #63 