### PR TITLE
Print out error messages on panic and memory allcoation failure

### DIFF
--- a/examples/qemu_project/src/main.rs
+++ b/examples/qemu_project/src/main.rs
@@ -80,6 +80,10 @@ fn main() -> ! {
             .set_priority(cortex_m::peripheral::scb::SystemHandler::PendSV, 7);
     }
 
+    fe_osi::set_putc(|c: char| {
+        write_byte(c as u8);
+    });
+
     //Start the FeRTOS scheduler
     let enable_systick = |reload: usize| {
         p.SYST.set_reload(reload as u32);

--- a/fe_osi/src/lib.rs
+++ b/fe_osi/src/lib.rs
@@ -8,10 +8,37 @@ pub mod ipc;
 pub mod semaphore;
 pub mod task;
 
+static mut PUTC: Option<fn(char)> = None;
+
 extern "C" {
     fn do_exit() -> usize;
     fn do_sleep(seconds: u32) -> usize;
     fn do_yield() -> usize;
+}
+
+/// Sets what is internally used for putc to print out error messages
+pub fn set_putc(putc: fn(char)) {
+    unsafe {
+        PUTC = Some(putc);
+    }
+}
+
+/// If a putc function has been set using set_putc, print a character
+/// using the putc function.
+pub fn putc(c: char) {
+    unsafe {
+        if let Some(callback) = PUTC {
+            callback(c);
+        }
+    }
+}
+
+/// If a putc function has been set using set_putc, print a string
+/// using the putc function
+pub fn print_msg(msg: &str) {
+    for c in msg.chars() {
+        putc(c);
+    }
 }
 
 /// Causes the calling task to exit.

--- a/fe_rtos/src/lib.rs
+++ b/fe_rtos/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
+#![feature(const_btree_new)]
 #![feature(const_mut_refs)]
 #![feature(linked_list_remove)]
-#![feature(const_btree_new)]
+#![feature(panic_info_message)]
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Let me know if you think there's a way to make this cleaner.

closes #82 