### PR TITLE
IPC: Unsubscribe on Drop or Task Exit

### DIFF
--- a/examples/qemu_project/src/main.rs
+++ b/examples/qemu_project/src/main.rs
@@ -36,10 +36,9 @@ fn writer_task(_: &mut usize) {
                 for c in msg {
                     write_byte(c);
                 }
-            },
-            None => {},
+            }
+            None => {}
         }
-
     }
 }
 

--- a/examples/qemu_project/src/main.rs
+++ b/examples/qemu_project/src/main.rs
@@ -45,10 +45,8 @@ fn writer_task(_: &mut usize) {
 fn test_task(_: &mut usize) {
     let _test: Arc<[u32]> = Arc::new([0; 200]);
     let _test2: Box<[u32]> = Box::new([0; 200]);
-    {
-        let _subscriber = fe_osi::ipc::Subscriber::new("stdout").unwrap();
-        fe_osi::sleep(1000);
-    }
+    let _subscriber = fe_osi::ipc::Subscriber::new("stdout").unwrap();
+    fe_osi::sleep(1000);
     fe_osi::exit();
     loop {}
 }

--- a/examples/qemu_project/src/main.rs
+++ b/examples/qemu_project/src/main.rs
@@ -23,24 +23,32 @@ fn hello_task(_: &mut usize) {
             alloc::format!("Hello, World! {} {:X}\r\n", counter, get_heap_remaining()).into_bytes();
         stdout.publish(msg).unwrap();
         counter += 1;
+        fe_osi::sleep(10);
     }
 }
 
 fn writer_task(_: &mut usize) {
     let mut subscriber = fe_osi::ipc::Subscriber::new("stdout").unwrap();
     loop {
-        let msg = subscriber.get_message().unwrap();
-
-        for c in msg {
-            write_byte(c);
+        match subscriber.get_message_nonblocking() {
+            Some(msg) => {
+                for c in msg {
+                    write_byte(c);
+                }
+            },
+            None => {},
         }
+
     }
 }
 
 fn test_task(_: &mut usize) {
     let _test: Arc<[u32]> = Arc::new([0; 200]);
     let _test2: Box<[u32]> = Box::new([0; 200]);
-    fe_osi::sleep(1000);
+    {
+        let _subscriber = fe_osi::ipc::Subscriber::new("stdout").unwrap();
+        fe_osi::sleep(1000);
+    }
     fe_osi::exit();
     loop {}
 }

--- a/examples/qemu_project/src/main.rs
+++ b/examples/qemu_project/src/main.rs
@@ -23,7 +23,8 @@ fn hello_task(_: &mut usize) {
             alloc::format!("Hello, World! {} {:X}\r\n", counter, get_heap_remaining()).into_bytes();
         stdout.publish(msg).unwrap();
         counter += 1;
-        fe_osi::sleep(10);
+        // Give the subscribers enough time to clear the entries
+        fe_osi::sleep(50);
     }
 }
 

--- a/examples/qemu_project/src/main.rs
+++ b/examples/qemu_project/src/main.rs
@@ -31,13 +31,10 @@ fn hello_task(_: &mut usize) {
 fn writer_task(_: &mut usize) {
     let mut subscriber = fe_osi::ipc::Subscriber::new("stdout").unwrap();
     loop {
-        match subscriber.get_message_nonblocking() {
-            Some(msg) => {
-                for c in msg {
-                    write_byte(c);
-                }
+        if let Some(msg) = subscriber.get_message_nonblocking() {
+            for c in msg {
+                write_byte(c);
             }
-            None => {}
         }
     }
 }

--- a/fe_osi/src/arm.s
+++ b/fe_osi/src/arm.s
@@ -9,6 +9,7 @@
     .global do_yield
     .global ipc_publish
     .global ipc_subscribe
+    .global ipc_unsubscribe
     .global ipc_get_message
     .global do_get_heap_remaining
     .global do_register_interrupt
@@ -66,21 +67,27 @@ ipc_subscribe:
     PUSH { LR }
     svc 0x8
     POP { PC }
-
+    
     .thumb_func
-ipc_get_message:
+ipc_unsubscribe:
     PUSH { LR }
     svc 0x9
     POP { PC }
 
     .thumb_func
-do_get_heap_remaining:
+ipc_get_message:
     PUSH { LR }
     svc 0xa
     POP { PC }
 
     .thumb_func
-do_register_interrupt:
+do_get_heap_remaining:
     PUSH { LR }
     svc 0xb
+    POP { PC }
+
+    .thumb_func
+do_register_interrupt:
+    PUSH { LR }
+    svc 0xc
     POP { PC }

--- a/fe_osi/src/ipc.rs
+++ b/fe_osi/src/ipc.rs
@@ -90,12 +90,12 @@ impl Subscriber {
             Ok(t) => t,
             Err(_) => return Err("Invalid topic string"),
         };
-
-        let resp = unsafe { ipc_subscribe((&c_topic).as_ptr()) };
+        let new_sub = Subscriber { topic: c_topic };
+        let resp = unsafe { ipc_subscribe((&new_sub.topic).as_ptr()) };
         if resp == 1 {
             Err("Failed to subscribe to topic.")
         } else {
-            Ok(Subscriber { topic: c_topic })
+            Ok(new_sub)
         }
     }
 

--- a/fe_osi/src/ipc.rs
+++ b/fe_osi/src/ipc.rs
@@ -120,10 +120,11 @@ impl Subscriber {
     pub fn get_message_nonblocking(&mut self) -> Option<Vec<u8>> {
         self.get_message_base(false)
     }
-
 }
 impl Drop for Subscriber {
     fn drop(&mut self) {
-        unsafe { ipc_unsubscribe((&self.topic).as_ptr()); }
+        unsafe {
+            ipc_unsubscribe((&self.topic).as_ptr());
+        }
     }
 }

--- a/fe_osi/src/ipc.rs
+++ b/fe_osi/src/ipc.rs
@@ -6,6 +6,7 @@ use cstr_core::{c_char, CString};
 extern "C" {
     fn ipc_publish(topic: *const c_char, msg_ptr: *mut u8, msg_len: usize) -> usize;
     fn ipc_subscribe(topic: *const c_char) -> usize;
+    fn ipc_unsubscribe(topic: *const c_char) -> usize;
     fn ipc_get_message(topic: *const c_char, block: bool) -> Message;
 }
 
@@ -118,5 +119,11 @@ impl Subscriber {
     /// If there are no new messages, it returns None
     pub fn get_message_nonblocking(&mut self) -> Option<Vec<u8>> {
         self.get_message_base(false)
+    }
+
+}
+impl Drop for Subscriber {
+    fn drop(&mut self) {
+        unsafe { ipc_unsubscribe((&self.topic).as_ptr()); }
     }
 }

--- a/fe_rtos/src/arm_syscall.s
+++ b/fe_rtos/src/arm_syscall.s
@@ -9,6 +9,7 @@
     .weak sys_yield
     .weak sys_ipc_publish
     .weak sys_ipc_subscribe
+    .weak sys_ipc_unsubscribe
     .weak sys_ipc_get_message
     .weak sys_get_heap_remaining
     .weak sys_interrupt_register
@@ -81,6 +82,7 @@ svc_addr_table:
     .word sys_yield              // 6
     .word sys_ipc_publish        // 7
     .word sys_ipc_subscribe      // 8
-    .word sys_ipc_get_message    // 9
-    .word sys_get_heap_remaining // 10
-    .word sys_interrupt_register // 11
+    .word sys_ipc_unsubscribe    // 9
+    .word sys_ipc_get_message    // 10
+    .word sys_get_heap_remaining // 11
+    .word sys_interrupt_register // 12

--- a/fe_rtos/src/ipc/mod.rs
+++ b/fe_rtos/src/ipc/mod.rs
@@ -29,9 +29,8 @@ impl TopicRegistry {
     }
 
     pub(crate) fn subscribe_to_topic(&mut self, subscriber_topic: &str) {
-        let sem: Semaphore = Semaphore::new(0);
         let pid: usize = unsafe { get_cur_task().pid };
-        let subscriber = Subscriber::new(sem, None);
+        let subscriber = Subscriber::new();
         let owned_topic = String::from(subscriber_topic);
         self.topic_lookup
             .entry(owned_topic)

--- a/fe_rtos/src/ipc/mod.rs
+++ b/fe_rtos/src/ipc/mod.rs
@@ -39,6 +39,13 @@ impl TopicRegistry {
             .add_subscriber(pid, subscriber);
     }
 
+    pub(crate) fn unsubscribe_from_topic(&mut self, subscriber_topic: &str) -> Option<Subscriber> {
+        let pid: usize = unsafe { get_cur_task().pid };
+        self.topic_lookup
+            .get_mut(subscriber_topic)
+            .and_then(|topic| topic.remove_subscriber(pid))
+    }
+
     pub(crate) fn get_ipc_message(&mut self, msg_topic: &str) -> Option<Vec<u8>> {
         let cur_pid: usize = unsafe { get_cur_task().pid };
 

--- a/fe_rtos/src/ipc/mod.rs
+++ b/fe_rtos/src/ipc/mod.rs
@@ -6,10 +6,10 @@ use crate::ipc::subscriber::{MessageNode, Subscriber};
 use crate::ipc::topic::Topic;
 use crate::task::get_cur_task;
 use alloc::collections::BTreeMap;
+use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use fe_osi::semaphore::Semaphore;
-use alloc::string::String;
 
 pub(crate) struct TopicRegistry {
     pub(crate) topic_lookup: BTreeMap<String, Topic>,

--- a/fe_rtos/src/ipc/subscriber.rs
+++ b/fe_rtos/src/ipc/subscriber.rs
@@ -15,10 +15,10 @@ pub(crate) struct Subscriber {
 }
 
 impl Subscriber {
-    pub(crate) fn new(sem: Semaphore, first_message: Option<Arc<MessageNode>>) -> Subscriber {
+    pub(crate) fn new() -> Subscriber {
         Subscriber {
-            lock: sem,
-            next_message: first_message,
+            lock: Semaphore::new(0),
+            next_message: None,
         }
     }
 }

--- a/fe_rtos/src/ipc/topic.rs
+++ b/fe_rtos/src/ipc/topic.rs
@@ -47,4 +47,8 @@ impl Topic {
         subscriber.next_message = None;
         self.subscribers.insert(pid, subscriber);
     }
+
+    pub(crate) fn remove_subscriber(&mut self, pid: usize) -> Option<Subscriber> {
+        self.subscribers.remove(&pid)
+    }
 }

--- a/fe_rtos/src/syscall.rs
+++ b/fe_rtos/src/syscall.rs
@@ -156,7 +156,7 @@ extern "C" fn sys_ipc_unsubscribe(c_topic: *const c_char) -> usize {
         ipc::TOPIC_REGISTERY_LOCK.with_lock(|| {
             success = match ipc::TOPIC_REGISTERY.unsubscribe_from_topic(topic) {
                 Some(_) => 0,
-                None => 1, 
+                None => 1,
             }
         });
         success

--- a/fe_rtos/src/syscall.rs
+++ b/fe_rtos/src/syscall.rs
@@ -5,8 +5,8 @@ use crate::interrupt;
 use crate::ipc;
 use crate::task;
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use alloc::string::String;
+use alloc::vec::Vec;
 use cstr_core::{c_char, CStr};
 use fe_osi::allocator::LayoutFFI;
 use fe_osi::ipc::Message;
@@ -27,7 +27,7 @@ extern "C" fn sys_exit() -> usize {
         ipc::TOPIC_REGISTERY_LOCK.with_lock(|| {
             let topics: Vec<String> = ipc::TOPIC_REGISTERY.topic_lookup.keys().cloned().collect();
             for topic in topics {
-                if let Some(_) = ipc::TOPIC_REGISTERY.unsubscribe_from_topic(&topic) {}
+                ipc::TOPIC_REGISTERY.unsubscribe_from_topic(&topic);
             }
         });
 

--- a/fe_rtos/src/syscall.rs
+++ b/fe_rtos/src/syscall.rs
@@ -23,14 +23,6 @@ pub fn link_syscalls() {}
 #[no_mangle]
 extern "C" fn sys_exit() -> usize {
     unsafe {
-        //let pid = task::get_cur_task().pid;
-        //ipc::TOPIC_REGISTERY_LOCK.take();
-        //for (name, topic) in &mut ipc::TOPIC_REGISTERY.topic_lookup {
-        //    print_msg(format!("Topic is: {}\r\n", name).as_str());
-        //    topic.subscribers.remove(&pid);
-        //}
-        //ipc::TOPIC_REGISTERY_LOCK.give();
-
         while !task::remove_task() {
             sys_yield();
         }
@@ -146,6 +138,28 @@ extern "C" fn sys_ipc_subscribe(c_topic: *const c_char) -> usize {
             ipc::TOPIC_REGISTERY.subscribe_to_topic(topic);
         });
         0
+    }
+}
+
+#[no_mangle]
+extern "C" fn sys_ipc_unsubscribe(c_topic: *const c_char) -> usize {
+    unsafe {
+        let topic: &str = match CStr::from_ptr(c_topic).to_str() {
+            Ok(topic) => topic,
+            Err(_) => {
+                // return early indicating failure
+                return 1;
+            }
+        };
+
+        let mut success = 1;
+        ipc::TOPIC_REGISTERY_LOCK.with_lock(|| {
+            success = match ipc::TOPIC_REGISTERY.unsubscribe_from_topic(topic) {
+                Some(_) => 0,
+                None => 1, 
+            }
+        });
+        success
     }
 }
 

--- a/fe_rtos/src/syscall.rs
+++ b/fe_rtos/src/syscall.rs
@@ -23,6 +23,14 @@ pub fn link_syscalls() {}
 #[no_mangle]
 extern "C" fn sys_exit() -> usize {
     unsafe {
+        //let pid = task::get_cur_task().pid;
+        //ipc::TOPIC_REGISTERY_LOCK.take();
+        //for (name, topic) in &mut ipc::TOPIC_REGISTERY.topic_lookup {
+        //    print_msg(format!("Topic is: {}\r\n", name).as_str());
+        //    topic.subscribers.remove(&pid);
+        //}
+        //ipc::TOPIC_REGISTERY_LOCK.give();
+
         while !task::remove_task() {
             sys_yield();
         }

--- a/fe_rtos/src/syscall.rs
+++ b/fe_rtos/src/syscall.rs
@@ -184,6 +184,10 @@ extern "C" fn sys_ipc_get_message(c_topic: *const c_char, block: bool) -> Messag
             sem_ref = ipc::TOPIC_REGISTERY.get_subscriber_lock(topic);
         });
 
+        if sem_ref.is_none() {
+            return get_null_message();
+        }
+
         if block {
             sem_ref.unwrap().take();
         } else if !sem_ref.unwrap().try_take() {

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -54,7 +54,7 @@ pub(crate) struct NewTaskInfo {
 
 const INIT_XPSR: usize = 0x01000000;
 /// The default and recommended stack size for a task.
-pub const DEFAULT_STACK_SIZE: usize = 1024;
+pub const DEFAULT_STACK_SIZE: usize = 1536;
 
 static mut KERNEL_STACK: [usize; DEFAULT_STACK_SIZE] = [0; DEFAULT_STACK_SIZE];
 static mut TICKS: TickCounter = TickCounter::new();


### PR DESCRIPTION
Leaving open subscribers after a task exits quickly causes memory issues as there's no way to free up old messages that no active tasks are waiting on. This still requires either dropping the OSI subscriber, or calling fe_osi::exit(). 