### PR TITLE
Add a simple stack overflow check

### DIFF
--- a/fe_osi/src/allocator.rs
+++ b/fe_osi/src/allocator.rs
@@ -1,4 +1,4 @@
-use crate::{print_msg, putc};
+use crate::{print_msg, putc, usize_to_chars};
 use core::alloc::{GlobalAlloc, Layout};
 
 /// The allocator that should be used for standalone FeRTOS binaries.
@@ -42,26 +42,6 @@ unsafe impl GlobalAlloc for FeAllocator {
         };
         do_dealloc(ptr, layout_ffi);
     }
-}
-
-fn usize_to_chars(char_slice: &mut [u8], num: usize) -> usize {
-    let mut i = char_slice.len() - 1;
-    let mut val = num;
-
-    loop {
-        //This is some ascii shenanigans
-        char_slice[i] = ((val % 10) + 0x30) as u8;
-        val /= 10;
-
-        if val == 0 || i == 0 {
-            break;
-        }
-
-        i -= 1;
-    }
-
-    //This is the index where the caller should start printing from
-    i
 }
 
 #[alloc_error_handler]

--- a/fe_osi/src/lib.rs
+++ b/fe_osi/src/lib.rs
@@ -68,3 +68,38 @@ pub fn r#yield() -> usize {
 
     0
 }
+
+/// Puts the ASCII representation of `num` into char_slice.
+///
+/// # Return
+///
+/// returns the index of char_slice where the ascii representation begins.
+///
+/// #Examples
+///
+/// ```
+/// //You need a max of 20 digits to represent a 64 bit number
+/// let mut digits: [u8; 20] = [0; 20];
+/// let num = 1234;
+/// let start_index = usize_to_chars(&mut digits, num);
+/// let string: str = core::str::from_utf8(&digits[start_index..]).unwrap();
+/// ```
+pub fn usize_to_chars(char_slice: &mut [u8], num: usize) -> usize {
+    let mut i = char_slice.len() - 1;
+    let mut val = num;
+
+    loop {
+        //This is some ascii shenanigans
+        char_slice[i] = ((val % 10) + 0x30) as u8;
+        val /= 10;
+
+        if val == 0 || i == 0 {
+            break;
+        }
+
+        i -= 1;
+    }
+
+    //This is the index where the caller should start printing from
+    i
+}


### PR DESCRIPTION
In the kernel's task loop, check a canary value at the end of each task's stack.
If that value is overwritten, that means the stack has overflowed.

Sadly, this will not make a difference if FeRTOS locks up before the kernel has a chance to run. However, this will make it easier to diagnose a stack overflow with a debugger because you can always check the memory location of the canary.

closes #8 