### PR TITLE
Change the allocator to use a free list instead of in heap blocks.

### DIFF
--- a/examples/fertos_project/link_123.x
+++ b/examples/fertos_project/link_123.x
@@ -66,8 +66,7 @@ SECTIONS
 
   _sidata = LOADADDR(.data);
 
-  /* Make sure the heap is 8 byte aligned */
-  .heap ALIGN(0x8):
+  .heap :
   {
     _sheap = .;
     /* Make the heap 128k in size */

--- a/examples/fertos_project/link_1294.x
+++ b/examples/fertos_project/link_1294.x
@@ -66,8 +66,7 @@ SECTIONS
 
   _sidata = LOADADDR(.data);
 
-  /* Make sure the heap is 8 byte aligned */
-  .heap ALIGN(0x8):
+  .heap :
   {
     _sheap = .;
     /* Make the heap 128k in size */

--- a/examples/qemu_project/link.x
+++ b/examples/qemu_project/link.x
@@ -66,8 +66,7 @@ SECTIONS
 
   _sidata = LOADADDR(.data);
 
-  /* Make sure the heap is 8 byte aligned */
-  .heap ALIGN(0x8):
+  .heap :
   {
     _sheap = .;
     /* Determines the heap size */

--- a/fe_rtos/src/fe_alloc.rs
+++ b/fe_rtos/src/fe_alloc.rs
@@ -61,6 +61,9 @@ unsafe impl GlobalAlloc for KernelAllocator {
     }
 }
 
+// Returns the appropriate bit mask for a bit position with a certain number of
+// bits remaining to process. Also updates cur_block by the number of blocks/bits
+// included in the returned bit mask.
 fn get_bit_mask(bit: usize, blocks_remaining: usize, cur_block: &mut usize) -> u8 {
     // Look up table for potential bit masks
     const BIT_LUT: [u8; 8] = [0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F, 0xFF];

--- a/fe_rtos/src/fe_alloc.rs
+++ b/fe_rtos/src/fe_alloc.rs
@@ -11,15 +11,15 @@ use fe_osi::allocator::LayoutFFI;
 /******************************************************************************
 * The structure of a heap is the following:
 *    ---------------------------------------------
-*   | free list |         useable heap            |
+*   | free list |         usable heap            |
 *    ---------------------------------------------
 *   The beginning of the heap is reserved for the free list.
-*   The ith bit of the free list is 0 if the ith block in the useable heap is
+*   The ith bit of the free list is 0 if the ith block in the usable heap is
 *   unallocated and is 1 otherwise.
-*   The "useable heap" is the part of the heap that will be used to service
+*   The "usable heap" is the part of the heap that will be used to service
 *   dynamic memory allocations.
 *
-*   In the code below, the useable heap will simple be refered to as the "heap."
+*   In the code below, the usable heap will simple be refered to as the "heap."
 ******************************************************************************/
 
 const BLOCK_SIZE: usize = 0x10;

--- a/fe_rtos/src/fe_alloc.rs
+++ b/fe_rtos/src/fe_alloc.rs
@@ -217,7 +217,8 @@ unsafe fn init_heap() {
     // y = z * (8b)/(8b + 1)
     // We will also do some math to make sure that y % b == 0
     // We are also assuming the entire heap and heap size is block size aligned
-    let usable_heap_size = (total_heap_size * (8 * BLOCK_SIZE) / ((8 * BLOCK_SIZE) + 1)) & !(BLOCK_SIZE - 1);
+    let usable_heap_size =
+        (total_heap_size * (8 * BLOCK_SIZE) / ((8 * BLOCK_SIZE) + 1)) & !(BLOCK_SIZE - 1);
     NUM_BLOCKS = usable_heap_size / BLOCK_SIZE;
     let free_list_size = total_heap_size - usable_heap_size;
     HEAP = FREE_LIST.add(free_list_size);

--- a/fe_rtos/src/spinlock.rs
+++ b/fe_rtos/src/spinlock.rs
@@ -53,9 +53,7 @@ impl Spinlock {
 
         if self.count.load(Ordering::SeqCst) <= 1 {
             self.pid.store(0, Ordering::SeqCst);
-            self.count.store(0, Ordering::SeqCst);
-        } else {
-            self.count.fetch_sub(1, Ordering::SeqCst);
         }
+        self.count.fetch_sub(1, Ordering::SeqCst);
     }
 }


### PR DESCRIPTION
This new heap works as follows:
    ---------------------------------------------
   | free list |         useable heap            |
    ---------------------------------------------
   The beginning of the heap is reserved for the free list.
   The ith bit of the free list is 0 if the ith block in the useable heap is
   unallocated and is 1 otherwise.
   The "useable heap" is the part of the heap that will be used to service
   dynamic memory allocations.

The main advantage of this is that if a naughty task were to accidentaly write
to the data outside its allocated region, it has a much lower chance of overwritting
heap metadata. A very convinient consequence to this is that FeRTOS will be more likely
to detect stack overflows because it won't be locked up in the allocator (though it
still can't catch every stack overflow).
Another advantage is that other than setting up the heap, I think the code is now simpler.

However, an obvious disadvantage is that allocations and deallocations will likely be slower,
and this strategy does not scale well with large heaps. However, FeRTOS is designed
for embedded applications, so that might not be that much of a problem.

Signed-off-by: Bijan Tabatabai <bijan311@gmail.com>

Do you guys think this is better?
It does pick up stack overflows from the IPC message node dropping about one quarter to one half of the time one qemu which is nice.

This doesn't "optimize" the allocator, it might even do the opposite, but this is changing the allocator significantly, so I'll tag #5 here