### PR TITLE
Race condition fix

### DIFF
--- a/examples/qemu_project/src/main.rs
+++ b/examples/qemu_project/src/main.rs
@@ -39,11 +39,15 @@ fn writer_task(_: &mut usize) {
 }
 
 fn test_task(_: &mut usize) {
-    let _test: Arc<[u32]> = Arc::new([0; 200]);
-    let _test2: Box<[u32]> = Box::new([0; 200]);
-    let _subscriber = fe_osi::ipc::Subscriber::new("stdout").unwrap();
-    fe_osi::sleep(1000);
-    fe_osi::exit();
+    {
+        let _test: Arc<[u32]> = Arc::new([0; 200]);
+        let _test2: Box<[u32]> = Box::new([0; 200]);
+        let _subscriber = fe_osi::ipc::Subscriber::new("stdout").unwrap();
+        fe_osi::sleep(1000);
+    }
+    unsafe {
+        fe_osi::exit();
+    }
     loop {}
 }
 

--- a/fe_osi/src/allocator.rs
+++ b/fe_osi/src/allocator.rs
@@ -59,7 +59,9 @@ fn error_handler(layout: Layout) -> ! {
     print_msg(core::str::from_utf8(&digits[start_idx..]).unwrap());
     putc('\n');
 
-    crate::exit();
+    unsafe {
+        crate::exit();
+    }
 
     loop {}
 }

--- a/fe_osi/src/lib.rs
+++ b/fe_osi/src/lib.rs
@@ -42,10 +42,12 @@ pub fn print_msg(msg: &str) {
 }
 
 /// Causes the calling task to exit.
-pub fn exit() -> usize {
-    unsafe {
-        do_exit();
-    }
+///
+/// # Safety
+/// Calls to this function may result in a memory leak if the calling task has
+/// not freed all of its dynamically allocated memory before hand.
+pub unsafe fn exit() -> usize {
+    do_exit();
     //Execution should never reach here
     loop {}
 }

--- a/fe_rtos/src/fe_alloc.rs
+++ b/fe_rtos/src/fe_alloc.rs
@@ -232,8 +232,6 @@ unsafe fn init_heap() {
 }
 
 pub(crate) unsafe fn clear_deleted_task(pid: usize) {
-    //CLEARING_TASK is needed because dropping a box will
-    //enable interrupts
     let mut i = 0;
 
     ALLOC_LOCK.take();

--- a/fe_rtos/src/interrupt.rs
+++ b/fe_rtos/src/interrupt.rs
@@ -61,9 +61,8 @@ fn panic(panic_info: &PanicInfo<'_>) -> ! {
     }
     unsafe {
         super::enable_interrupts();
+        fe_osi::exit();
     }
-
-    fe_osi::exit();
 
     loop {}
 }

--- a/fe_rtos/src/syscall.rs
+++ b/fe_rtos/src/syscall.rs
@@ -112,8 +112,6 @@ extern "C" fn sys_ipc_publish(c_topic: *const c_char, msg_ptr: *mut u8, msg_len:
         let topic: &str = match CStr::from_ptr(c_topic).to_str() {
             Ok(topic) => topic,
             Err(_) => {
-                // Invalid topic string. Create vector so the compiler can dealloc
-                Vec::from_raw_parts(msg_ptr, msg_len, msg_len);
                 // return early indicating failure
                 return 1;
             }

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -258,7 +258,9 @@ pub(crate) fn new_task_helper(task_info: Box<NewTaskInfo>) -> ! {
 
     task_ep(task_param);
 
-    fe_osi::exit();
+    unsafe {
+        fe_osi::exit();
+    }
 
     loop {}
 }
@@ -343,7 +345,9 @@ fn kernel(_: &mut u32) {
                 fe_osi::print_msg("Stack overflow in task ");
                 fe_osi::print_msg(core::str::from_utf8(&digits[start_idx..]).unwrap());
                 fe_osi::print_msg("!\n");
-                fe_osi::exit();
+                unsafe {
+                    fe_osi::exit();
+                }
             }
 
             //We want to default to Runnable because if a task is in a transition state,

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -403,8 +403,9 @@ fn kernel(_: &mut u32) {
                 None => (),
             }
 
-            //Clear any remaining leftover dynamically allocated data
             unsafe {
+                SCHEDULER.remove_task(removed_task.pid);
+                //Clear any remaining leftover dynamically allocated data
                 crate::fe_alloc::clear_deleted_task(removed_task.pid);
             }
         }

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -405,8 +405,6 @@ fn kernel(_: &mut u32) {
 
             unsafe {
                 SCHEDULER.remove_task(removed_task.pid);
-                //Clear any remaining leftover dynamically allocated data
-                crate::fe_alloc::clear_deleted_task(removed_task.pid);
             }
         }
 


### PR DESCRIPTION
As it turns out, not all of my ideas are good.
This PR mainly removes FeRTOS's ability to deallocate memory that a task didn't get a chance to free itself. However, the implementation can cause a use-after-free error if tasks share memory and the allocating task exits. I could not think of a better solution, so I removed the functionality entirely.
This PR also makes calls to fe_osi::exit unsafe and adds documentation comments to explain that it can cause memory leaks.