### PR TITLE
Have fe_osi::spawn_task return Arc<Semaphore> to signal a task's exit

### DIFF
--- a/examples/qemu_project/src/main.rs
+++ b/examples/qemu_project/src/main.rs
@@ -53,8 +53,8 @@ fn test_task(_: &mut usize) {
 
 fn spawn_task(_: &mut usize) {
     loop {
-        fe_osi::task::task_spawn(fe_rtos::task::DEFAULT_STACK_SIZE, test_task, None);
-        fe_osi::sleep(2000);
+        fe_osi::task::task_spawn_block(fe_rtos::task::DEFAULT_STACK_SIZE, test_task, None);
+        fe_osi::sleep(1000);
     }
 }
 

--- a/fe_osi/src/task.rs
+++ b/fe_osi/src/task.rs
@@ -20,6 +20,7 @@ extern "C" {
 ///     loop {}
 /// }
 /// task_spawn(1024, test_task, None);
+/// ```
 pub fn task_spawn<T: Send>(
     stack_size: usize,
     entry_point: fn(&mut T),

--- a/fe_osi/src/task.rs
+++ b/fe_osi/src/task.rs
@@ -1,9 +1,15 @@
 extern crate alloc;
+use crate::semaphore::Semaphore;
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 use core::ptr::null_mut;
 
 extern "C" {
-    fn do_task_spawn(stack_size: usize, entry_point: *const u32, parameter: *mut u32);
+    fn do_task_spawn(
+        stack_size: usize,
+        entry_point: *const u32,
+        parameter: *mut u32,
+    ) -> *const Semaphore;
 }
 
 /// Creates a new task that will be run.
@@ -14,12 +20,27 @@ extern "C" {
 ///     loop {}
 /// }
 /// task_spawn(1024, test_task, None);
-pub fn task_spawn<T: Send>(stack_size: usize, entry_point: fn(&mut T), parameter: Option<Box<T>>) {
+pub fn task_spawn<T: Send>(
+    stack_size: usize,
+    entry_point: fn(&mut T),
+    parameter: Option<Box<T>>,
+) -> Arc<Semaphore> {
     unsafe {
         let param_ptr = match parameter {
             Some(param) => Box::into_raw(param) as *mut u32,
             None => null_mut(),
         };
-        do_task_spawn(stack_size, entry_point as *const u32, param_ptr);
+        let raw_sem = do_task_spawn(stack_size, entry_point as *const u32, param_ptr);
+        Arc::from_raw(raw_sem)
     }
+}
+
+/// Creates a new task that will be run and blocks until that task exits.
+pub fn task_spawn_block<T: Send>(
+    stack_size: usize,
+    entry_point: fn(&mut T),
+    parameter: Option<Box<T>>,
+) {
+    let sem = task_spawn(stack_size, entry_point, parameter);
+    sem.take();
 }

--- a/fe_rtos/src/task/mod.rs
+++ b/fe_rtos/src/task/mod.rs
@@ -50,9 +50,18 @@ pub(crate) struct Task {
 unsafe impl Send for Task {}
 unsafe impl Sync for Task {}
 
+impl Task {
+    pub(crate) fn give(&self) {
+        if let Some(task_info) = &self.task_info {
+            task_info.sem.give();
+        }
+    }
+}
+
 pub(crate) struct NewTaskInfo {
     pub ep: *const u32,
     pub param: *mut u32,
+    pub sem: Arc<Semaphore>,
 }
 
 pub(crate) const STACK_CANARY: usize = 0xC0DE5AFE;


### PR DESCRIPTION
This will make it easier for tasks to block on a task they spawn, which can be
desirable when doing parallel tasks

closes #36 
This doesn't create a new syscall like #36 asks, and instead allows the caller to decide whether or not it wants to block, as well as when it wants to block, by using the returned Semaphore. I think this is much better than a new syscall.